### PR TITLE
Update URI for package registry for elm 0.19

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ if (!elmJson && !elmPackageJson) {
   );
   process.exit(1);
 } else if (elmJson) {
-  fetch("https://package.elm-lang.org/all-packages?elm-package-version=0.19")
+  fetch("https://package.elm-lang.org/all-packages")
     .then(data => {
       let parsedJson;
 


### PR DESCRIPTION
Fixes issue #12. The `?elm-package-version=0.19` query parameter does not work properly for the current API. Not sure exactly when this changed at package.elm-lang.org , but the problem was present as of 2020-03-13 as experienced by multiple people in different locations.
Removing the query parameter restores the access to registry json that includes 0.19 (and earlier, apparently) packages in the same json format as expected by the existing code.